### PR TITLE
Globs

### DIFF
--- a/daemon.go
+++ b/daemon.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -11,6 +12,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/sns"
 	"github.com/aws/aws-sdk-go/service/sqs"
+	"github.com/ryanuber/go-glob"
 	"go.uber.org/zap"
 )
 
@@ -82,14 +84,24 @@ func NewDaemon(
 	daemon.queue = queue
 
 	daemon.asgTaggers = make(map[string]*AutoscalingTagger)
+
+	// Give it a very generous 1 minute to page through all ASGs
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute*1)
+	defer cancel()
+	asgNameList, err := daemon.listAutoscalingGroupNames(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	// Iterate over the configured ASGs and the actual ASGs and check for glob matches (or exact matches)
 	for _, conf := range config.TaggingConfigs {
-		daemon.addTagger(conf.ASGName, &conf)
+		for _, asgName := range asgNameList {
+			if glob.Glob(conf.ASGName, asgName) {
+				daemon.addTagger(asgName, &conf)
+			}
+		}
 	}
 	return daemon, nil
-}
-
-func (d *Daemon) addTagger(asgName string, tags *TaggingConfig) {
-	d.asgTaggers[asgName] = NewAutoscalingTagger(asgName, tags, d.queue, d.asgClient, d.ec2Client, d.log)
 }
 
 func (d *Daemon) Start(ctx context.Context) error {
@@ -176,4 +188,23 @@ func (d *Daemon) Start(ctx context.Context) error {
 			}
 		}
 	}
+}
+
+func (d *Daemon) listAutoscalingGroupNames(ctx context.Context) ([]string, error) {
+	asgList := []string{}
+	input := &autoscaling.DescribeAutoScalingGroupsInput{}
+	err := d.asgClient.DescribeAutoScalingGroupsPagesWithContext(ctx, input, func(page *autoscaling.DescribeAutoScalingGroupsOutput, lastPage bool) bool {
+		for _, asg := range page.AutoScalingGroups {
+			asgList = append(asgList, *asg.AutoScalingGroupName)
+		}
+		return true
+	})
+	if err != nil {
+		return nil, err
+	}
+	return asgList, nil
+}
+
+func (d *Daemon) addTagger(asgName string, tags *TaggingConfig) {
+	d.asgTaggers[asgName] = NewAutoscalingTagger(asgName, tags, d.queue, d.asgClient, d.ec2Client, d.log)
 }

--- a/daemon.go
+++ b/daemon.go
@@ -107,6 +107,10 @@ func NewDaemon(
 func (d *Daemon) Start(ctx context.Context) error {
 	d.log.Info("Starting Daemon")
 
+	for _, asg := range d.asgTaggers {
+		d.log.Info(fmt.Sprintf("Managing tags for ASG %s", asg.asgName))
+	}
+
 	// If the SNS topic is not empty, let Tagd subscribe and enable asg notifications
 	if d.config.SNSTopicARN != "" {
 		d.log.Debug("Subscribing SQS queue to SNS topic", zap.String("topic", d.queue.topicArn))
@@ -138,13 +142,12 @@ func (d *Daemon) Start(ctx context.Context) error {
 			}
 		}
 	}
-	d.log.Debug("Listening to SQS Queue...")
 	for {
 		select {
 		case <-ctx.Done():
 			return nil
 		default:
-			d.log.Debug("Polling SQS for messages", zap.String("queueURL", d.queue.url))
+			d.log.Info("Polling SQS for messages", zap.String("queueURL", d.queue.url))
 			messages, err := d.queue.GetMessages(ctx)
 			if err != nil {
 				d.log.Warn("Failed to get messages from SQS", zap.Error(err))

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.14
 
 require (
 	github.com/aws/aws-sdk-go v1.33.4
+	github.com/ryanuber/go-glob v1.0.0
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.7.0
 	go.uber.org/zap v1.15.0

--- a/go.sum
+++ b/go.sum
@@ -152,6 +152,8 @@ github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40T
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
+github.com/ryanuber/go-glob v1.0.0 h1:iQh3xXAumdQ+4Ufa5b25cRpC5TYKlno6hsv6Cb3pkBk=
+github.com/ryanuber/go-glob v1.0.0/go.mod h1:807d1WSdnB0XRJzKNil9Om6lcp/3a0v4qIHxIXzX/Yc=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d h1:zE9ykElWQ6/NYmHa3jpm/yHnI4xSofP+UP6SpjHcSeM=


### PR DESCRIPTION
Add ability to handle globs in config.

For example: 
```
tagConfig:
  - asgName: "nodes.*.example.org"
    tags:
      "Team": "Development 
```
Allows us to manage `nodes.eu.example.org`, `nodes.us.example.org` etc. in one line of config.

Supports prefixed and suffixed globs as well as globs in the middle of text.
